### PR TITLE
- "vcd_nsxt_ipsec_vpn_tunnel" Module Release 1.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.tfstate.*
 secrets.tfvars
 secrets.auto.tfvars
+terraform.tfvars
+terraform.auto.tfvars
 providers.tf
 
 # Crash log files

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform VMware Cloud Director NSX-T IPSec VPN Tunnel Module
 
-This Terraform module will deploy an IPSec VPN Tunnel on an NSX-T Edge Gateway in a VMware Cloud Director (VCD) environment. This module can be used to provsion a new IPSec VPN Tunnel into [Rackspace Technology SDDC Flex](https://www.rackspace.com/cloud/private/software-defined-data-center-flex) VCD Data Center Regions.
+This Terraform module will deploy an IPSec VPN Tunnel on an NSX-T Edge Gateway in a VMware Cloud Director (VCD) environment. This module can be used to provision a new IPSec VPN Tunnel into [Rackspace Technology SDDC Flex](https://www.rackspace.com/cloud/private/software-defined-data-center-flex) VCD Data Center Regions.
 
 ## Requirements
 
@@ -57,7 +57,7 @@ This Terraform module will deploy an IPSec VPN Tunnel on an NSX-T Edge Gateway i
 
 ```terraform
 module "vcd_nsxt_ipsec_vpn_tunnel" {
-  source                = "github.com/global-vmware/vcd_nsxt_ipsec_vpn_tunnel.git?ref=v1.1.0"
+  source                = "github.com/global-vmware/vcd_nsxt_ipsec_vpn_tunnel.git?ref=v1.1.1"
 
   vdc_org_name          = "<US1-VDC-ORG-NAME>"
   vdc_group_name        = "<US1-VDC-GRP-NAME>"

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ terraform {
 }
 
 data "vcd_vdc_group" "dcgroup" {
+  org   = var.vdc_org_name
   name  = var.vdc_group_name
 }
 
@@ -20,28 +21,31 @@ data "vcd_nsxt_edgegateway" "edge_gateway" {
 }
 
 data "vcd_library_certificate" "cert" {
+  org   = var.vdc_org_name
   count = var.authentication_mode == "CERTIFICATE" ? 1 : 0
   alias = var.certificate_alias
 }
 
 data "vcd_library_certificate" "ca-cert" {
+  org   = var.vdc_org_name
   count = var.authentication_mode == "CERTIFICATE" ? 1 : 0
   alias = var.ca_certificate_alias
 }
 
 resource "vcd_nsxt_ipsec_vpn_tunnel" "tunnel" {
-  edge_gateway_id = data.vcd_nsxt_edgegateway.edge_gateway.id
+  org               = var.vdc_org_name
+  edge_gateway_id   = data.vcd_nsxt_edgegateway.edge_gateway.id
 
-  name              = var.name
-  description       = var.description
-  enabled           = var.enabled
-  pre_shared_key    = var.authentication_mode == "PSK" ? var.pre_shared_key : ""
-  local_ip_address  = var.local_ip_address
-  local_networks    = var.local_networks
-  remote_ip_address = var.remote_ip_address
-  remote_id         = var.remote_id
-  remote_networks   = var.remote_networks
-  logging           = var.logging
+  name                = var.name
+  description         = var.description
+  enabled             = var.enabled
+  pre_shared_key      = var.authentication_mode == "PSK" ? var.pre_shared_key : ""
+  local_ip_address    = var.local_ip_address
+  local_networks      = var.local_networks
+  remote_ip_address   = var.remote_ip_address
+  remote_id           = var.remote_id
+  remote_networks     = var.remote_networks
+  logging             = var.logging
 
   authentication_mode = var.authentication_mode
   certificate_id      = var.authentication_mode == "CERTIFICATE" ? data.vcd_library_certificate.cert[0].id : null


### PR DESCRIPTION
- "vcd_nsxt_ipsec_vpn_tunnel" Module Release 1.1.1

- Added the "org" Argument to the "vcd_vdc_group" Data Source

- Added the "org" Argument to the "vcd_library_certificate" Data Sources

- Added the "org" Argument to the "vcd_nsxt_ipsec_vpn_tunnel" Resource

- Updated the source URL Reference in the "vcd_nsxt_ipsec_vpn_tunnel" Module Code Snippet to Version 1.1.1 in the Example Usage Section of the README